### PR TITLE
Bump SDK version to 0.23.x.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,3 @@
 source 'https://github.com/twilio/cocoapod-specs'
 
-pod 'TwilioConversationsClient', '~>0.22.0'
+pod 'TwilioConversationsClient', '~>0.23.0'

--- a/Sources/Modules/ConversationViewController.m
+++ b/Sources/Modules/ConversationViewController.m
@@ -54,8 +54,8 @@
         self.camera.videoTrack.delegate = self;
     }
 
-    /* For this demonstration, we always use Speaker audio output (vs. TWCAudioOutputReceiver) */
-    [TwilioConversationsClient setAudioOutput:TWCAudioOutputSpeaker];
+    /* For this demonstration, we just use the default audio output. */
+    [TwilioConversationsClient setAudioOutput:TWCAudioOutputDefault];
 }
 
 - (void)didReceiveMemoryWarning {


### PR DESCRIPTION
Updates this sample to work with 0.23.x.

Do not merge until 0.23.0 is live.