### PR TITLE
Using TwilioVideo 1.0.0-beta5

### DIFF
--- a/ObjCVideoQuickstart/ViewController.m
+++ b/ObjCVideoQuickstart/ViewController.m
@@ -57,10 +57,6 @@
     // LocalMedia represents the collection of tracks that we are sending to other Participants from our VideoClient.
     self.localMedia = [[TVILocalMedia alloc] init];
     
-    // 1.0.0-beta4 incorrectly chooses `TVIAudioOutputVoiceChatDefault` by default. We work around this by restoring the intended default value.
-    TVIAudioController *audioController = self.localMedia.audioController;
-    audioController.audioOutput = TVIAudioOutputVideoChatDefault;
-    
     if ([PlatformUtils isSimulator]) {
         [self.previewView removeFromSuperview];
     } else {

--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/twilio/cocoapod-specs'
 
 target 'ObjCVideoQuickstart' do
-  pod 'TwilioVideo', '1.0.0-beta4'
+  pod 'TwilioVideo', '1.0.0-beta5'
 end


### PR DESCRIPTION
- Uses 1.0.0-beta5
- Removed the audio route work around as Video SDK version 1.0.0-beta5 correctly chooses `TVIAudioOutputVideoChatDefault`  by default