### PR TITLE
Decapitalize room text field by default

### DIFF
--- a/AVPlayerExample/ViewController.m
+++ b/AVPlayerExample/ViewController.m
@@ -90,6 +90,7 @@ NSString *const kStatusKey   = @"status";
     // Start with the Lobby UI
     [self showInterfaceState:ViewControllerStateLobby];
 
+    self.roomTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
     self.roomTextField.delegate = self;
 
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];

--- a/ObjCVideoQuickstart/ViewController.m
+++ b/ObjCVideoQuickstart/ViewController.m
@@ -63,6 +63,7 @@
     self.disconnectButton.hidden = YES;
     self.micButton.hidden = YES;
     
+    self.roomTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
     self.roomTextField.delegate = self;
 
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];


### PR DESCRIPTION
When developers start by creating a token in the Twilio console and specify a room name when generating a token the default capitalization on the page is lower case while in this app it's upper case which can lead to confusion when getting started since room names are case sensitive.