### PR TITLE
Consume twilio-video-ios-2.8.0.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ workspace 'VideoQuickStart'
 platform :ios, '9.0'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '~> 2.7'
+  pod 'TwilioVideo', '~> 2.8'
 
   target 'ObjCVideoQuickstart' do
     project 'ObjCVideoQuickstart.xcproject'


### PR DESCRIPTION
Simple version bump. The Dominant Speaker APIs are optional, and we don't have an Objective-C sample that implements them.