### PR TITLE
ISDK-1683: Added deprecation notice to 3.0.0-beta README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > **Deprecation Notice - video-quickstart-objc repository**
 >
-> This repository has been deprecated and shall no longer be maintained. All Objective-C examples have been merged into the [video-quickstart-ios](https://github.com/twilio/video-quickstart-ios) repository and shall continued to be maintained there.
+> This repository has been deprecated and will no longer be maintained. All Objective-C examples have been merged into the [video-quickstart-ios](https://github.com/twilio/video-quickstart-ios) repository and will continue to be maintained there.
 >
 > NOTE: These sample applications use the Twilio Video 3.x APIs. For examples using our 2.x APIs, please see the [master](https://github.com/twilio/video-quickstart-objc) branch. For examples using our 1.x APIs, please see the [1.x](https://github.com/twilio/video-quickstart-objc/tree/1.x) branch.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 # Twilio Video Quickstart for Objective-C
 
+> **Deprecation Notice - video-quickstart-objc repository**
+>
+> This repository has been deprecated and shall no longer be maintained. All Objective-C examples have been merged into the [video-quickstart-ios](https://github.com/twilio/video-quickstart-ios) repository and shall continued to be maintained there.
+>
 > NOTE: These sample applications use the Twilio Video 3.x APIs. For examples using our 2.x APIs, please see the [master](https://github.com/twilio/video-quickstart-objc) branch. For examples using our 1.x APIs, please see the [1.x](https://github.com/twilio/video-quickstart-objc/tree/1.x) branch.
 
 Get started with Video on iOS:


### PR DESCRIPTION
Added a deprecation notice and link to the video-quickstart-ios repository.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
